### PR TITLE
jQuery 1.6.2 update + přemístění javascriptu

### DIFF
--- a/app/templates/@layout.latte
+++ b/app/templates/@layout.latte
@@ -22,9 +22,6 @@
 	<link rel="stylesheet" media="screen,projection,tv" href="{$basePath}/css/screen.css" type="text/css">
 	<link rel="stylesheet" media="print" href="{$basePath}/css/print.css" type="text/css">
 	<link rel="shortcut icon" href="{$basePath}/favicon.ico" type="image/x-icon">
-
-	<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6/jquery.min.js"></script>
-	<script type="text/javascript" src="{$basePath}/js/netteForms.js"></script>
 	{block head}{/block}
 </head>
 
@@ -32,5 +29,9 @@
 	<div n:foreach="$flashes as $flash" class="flash {$flash->type}">{$flash->message}</div>
 
 	{include #content}
+
+	<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
+	<script type="text/javascript" src="{$basePath}/js/netteForms.js"></script>
+	{block js}{/block}
 </body>
 </html>


### PR DESCRIPTION
jQuery 1.6.2 update + přemístění javascriptu ze sekce <head> na konec <body> viz. best practice http://developer.yahoo.com/performance/rules.html#js_bottom
