### PR TITLE
Fixed typo in session expiration - there was 7 days instead of 14 days.

### DIFF
--- a/app/config/config.neon
+++ b/app/config/config.neon
@@ -22,7 +22,7 @@ common:
 
 	nette:
 		session:
-			expiration: '+ 7 days'
+			expiration: '+ 14 days'
 
 		database:
 			default:


### PR DESCRIPTION
This typo was causing following error if "Remember me" checkbox has been checked:
The expiration time is greater than the session expiration 604800 seconds
