### PR TITLE
config.neon - added 'autoStart' session option

### DIFF
--- a/app/config/config.neon
+++ b/app/config/config.neon
@@ -18,7 +18,7 @@ nette:
 
 	session:
 		expiration: 14 days
-		autoStart: smart
+		autoStart: yes
 
 services:
 	- Model\UserManager


### PR DESCRIPTION
To avoid notices with using form protection in sandbox.
https://github.com/nette/nette/issues/1145
