### PR TITLE
Configuration: php settings moved to local config file

### DIFF
--- a/app/config/config.local.neon
+++ b/app/config/config.local.neon
@@ -1,3 +1,7 @@
+php:
+	date.timezone: Europe/Prague
+	zlib.output_compression: no
+
 parameters:
 
 nette:

--- a/app/config/config.neon
+++ b/app/config/config.neon
@@ -6,10 +6,6 @@
 #
 parameters:
 
-php:
-	date.timezone: Europe/Prague
-	# zlib.output_compression: yes
-
 nette:
 	application:
 		errorPresenter: Error


### PR DESCRIPTION
Notes:
- The timezone option has been simply moved.
- The disabled `zlib.output_compression` **yes** has been changed to enabled and probably safer **no** and has been moved too.
- It would be also cool to add information about php configuring to the http://doc.nette.org/cs/configuring page. Currently only in **Session** section is mentioned the ability to configure php with a link to the PHP site. The directives set in the **sandbox** should be mentioned on that page.
