### PR TITLE
added .map extension to allowed filenames

### DIFF
--- a/www/.htaccess
+++ b/www/.htaccess
@@ -16,7 +16,7 @@
 	# front controller
 	RewriteCond %{REQUEST_FILENAME} !-f
 	RewriteCond %{REQUEST_FILENAME} !-d
-	RewriteRule !\.(pdf|js|ico|gif|jpg|png|css|rar|zip|tar\.gz)$ index.php [L]
+	RewriteRule !\.(pdf|js|ico|gif|jpg|png|css|rar|zip|tar\.gz|map)$ index.php [L]
 </IfModule>
 
 # enable gzip compression


### PR DESCRIPTION
Some HTML templates refer to optional .map files. As they are often not present and the .htaccess does not exclude .map files from redirecting to index.php, Nette was often wrongly loaded for these files.
