### PR TITLE
log exception when bad link detected

### DIFF
--- a/app/presenters/ErrorPresenter.php
+++ b/app/presenters/ErrorPresenter.php
@@ -32,8 +32,16 @@ class ErrorPresenter extends BasePresenter
 			$code = $exception->getCode();
 			// load template 403.latte or 404.latte or ... 4xx.latte
 			$this->setView(in_array($code, array(403, 404, 405, 410, 500)) ? $code : '4xx');
-			// log to access.log
-			$this->logger->log("HTTP code $code: {$exception->getMessage()} in {$exception->getFile()}:{$exception->getLine()}", 'access');
+
+			if ($code === 404 && ($referer = $this->getHttpRequest()->getHeader('referer')) !== NULL
+				&& preg_match(sprintf("#^https?://[\\.a-z0-9]++(?<=[/\\.]%s)#", preg_quote($this->getHttpRequest()->getUrl()->getHost())), $referer)
+			) {
+				// bad link - log exception
+				$this->logger->log($exception, ILogger::EXCEPTION);
+			} else {
+				// log to access.log
+				$this->logger->log("HTTP code $code: {$exception->getMessage()} in {$exception->getFile()}:{$exception->getLine()}", 'access');
+			}
 
 		} else {
 			$this->setView('500'); // load template 500.latte


### PR DESCRIPTION
When 404 occurred after pass through an anchor with referer on site self, it is probably bad link inside application self and not user's typo or search engine wrong index - it might be worth to send report.
