### PR TITLE
fix router namespace

### DIFF
--- a/app/config/config.neon
+++ b/app/config/config.neon
@@ -20,4 +20,4 @@ services:
 	- App\Forms\FormFactory
 	- App\Forms\SignInFormFactory
 	- App\Forms\SignUpFormFactory
-	router: App\RouterFactory::createRouter
+	router: App\Router\RouterFactory::createRouter

--- a/app/router/RouterFactory.php
+++ b/app/router/RouterFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App;
+namespace App\Router;
 
 use Nette;
 use Nette\Application\Routers\RouteList;


### PR DESCRIPTION
I don't know, where this got lost. Probably when moving `RouterFactory` from `/app` directory.
Just to be compatible with other namespaced classes.