### PR TITLE
htaccess - no rewrite non-exists .svg files

### DIFF
--- a/www/.htaccess
+++ b/www/.htaccess
@@ -20,7 +20,7 @@
 	# front controller
 	RewriteCond %{REQUEST_FILENAME} !-f
 	RewriteCond %{REQUEST_FILENAME} !-d
-	RewriteRule !\.(pdf|js|ico|gif|jpg|png|css|rar|zip|tar\.gz|map)$ index.php [L]
+	RewriteRule !\.(pdf|js|ico|gif|jpg|png|svg|css|rar|zip|tar\.gz|map)$ index.php [L]
 </IfModule>
 
 # enable gzip compression


### PR DESCRIPTION
SVG is currently mostly used format in web. I see few case this rule is missing.

BC break: No