### PR TITLE
ICONV_IMPL can be unknown on Alpine linux

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,2 @@
+Order Allow,Deny
+Deny from all

--- a/.htaccess
+++ b/.htaccess
@@ -1,2 +1,1 @@
-Order Allow,Deny
-Deny from all
+Require all denied

--- a/app/forms/FormFactory.php
+++ b/app/forms/FormFactory.php
@@ -8,7 +8,7 @@ use Nette;
 use Nette\Application\UI\Form;
 
 
-class FormFactory
+final class FormFactory
 {
 	use Nette\SmartObject;
 

--- a/app/forms/SignInFormFactory.php
+++ b/app/forms/SignInFormFactory.php
@@ -9,7 +9,7 @@ use Nette\Application\UI\Form;
 use Nette\Security\User;
 
 
-class SignInFormFactory
+final class SignInFormFactory
 {
 	use Nette\SmartObject;
 

--- a/app/forms/SignUpFormFactory.php
+++ b/app/forms/SignUpFormFactory.php
@@ -9,7 +9,7 @@ use Nette;
 use Nette\Application\UI\Form;
 
 
-class SignUpFormFactory
+final class SignUpFormFactory
 {
 	use Nette\SmartObject;
 

--- a/app/model/UserManager.php
+++ b/app/model/UserManager.php
@@ -74,6 +74,7 @@ final class UserManager implements Nette\Security\IAuthenticator
 	 */
 	public function add(string $username, string $email, string $password): void
 	{
+		Nette\Utils\Validators::assert($email, 'email');
 		try {
 			$this->database->table(self::TABLE_NAME)->insert([
 				self::COLUMN_NAME => $username,

--- a/app/model/UserManager.php
+++ b/app/model/UserManager.php
@@ -11,7 +11,7 @@ use Nette\Security\Passwords;
 /**
  * Users management.
  */
-class UserManager implements Nette\Security\IAuthenticator
+final class UserManager implements Nette\Security\IAuthenticator
 {
 	use Nette\SmartObject;
 

--- a/app/presenters/Error4xxPresenter.php
+++ b/app/presenters/Error4xxPresenter.php
@@ -7,7 +7,7 @@ namespace App\Presenters;
 use Nette;
 
 
-class Error4xxPresenter extends BasePresenter
+final class Error4xxPresenter extends BasePresenter
 {
 	public function startup(): void
 	{

--- a/app/presenters/ErrorPresenter.php
+++ b/app/presenters/ErrorPresenter.php
@@ -10,7 +10,7 @@ use Nette\Http;
 use Tracy\ILogger;
 
 
-class ErrorPresenter implements Nette\Application\IPresenter
+final class ErrorPresenter implements Nette\Application\IPresenter
 {
 	use Nette\SmartObject;
 

--- a/app/presenters/HomepagePresenter.php
+++ b/app/presenters/HomepagePresenter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Presenters;
 
 
-class HomepagePresenter extends BasePresenter
+final class HomepagePresenter extends BasePresenter
 {
 	public function renderDefault(): void
 	{

--- a/app/presenters/SignPresenter.php
+++ b/app/presenters/SignPresenter.php
@@ -8,7 +8,7 @@ use App\Forms;
 use Nette\Application\UI\Form;
 
 
-class SignPresenter extends BasePresenter
+final class SignPresenter extends BasePresenter
 {
 	/** @persistent */
 	public $backlink = '';

--- a/app/presenters/templates/@layout.latte
+++ b/app/presenters/templates/@layout.latte
@@ -27,7 +27,7 @@
 
 	{block scripts}
 	<script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
-	<script src="https://nette.github.io/resources/js/netteForms.min.js"></script>
+	<script src="https://nette.github.io/resources/js/3/netteForms.min.js"></script>
 	<script src="{$basePath}/js/main.js"></script>
 	{/block}
 </body>

--- a/app/router/RouterFactory.php
+++ b/app/router/RouterFactory.php
@@ -9,7 +9,7 @@ use Nette\Application\Routers\Route;
 use Nette\Application\Routers\RouteList;
 
 
-class RouterFactory
+final class RouterFactory
 {
 	use Nette\StaticClass;
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 		"nette/security": "^3.0",
 		"nette/utils": "^3.0",
 		"latte/latte": "^3.0",
-		"tracy/tracy": "^2.4",
+		"tracy/tracy": "^3.0",
 		"dg/adminer-custom": "^1.8"
 	},
 	"require-dev": {

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ To use it, browse to the subdirectory `/adminer` in your project root (i.e. `htt
 Notice: Composer PHP version
 ----------------------------
 
-This project forces PHP 5.6 (eventually 7.1) as your PHP version for Composer packages. If you have newer 
+This project forces PHP 5.6 (eventually 7.1) as your PHP version for Composer packages. If you have newer
 version on production server you should change it in `composer.json`:
 
 ```json

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -1,5 +1,5 @@
-# Apache configuration file (see httpd.apache.org/docs/current/mod/quickreference.html)
-Allow from all
+# Apache configuration file (see https://httpd.apache.org/docs/current/mod/quickreference.html)
+Require all granted
 
 # disable directory listing
 <IfModule mod_autoindex.c>

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -21,7 +21,7 @@ Allow from all
 	# front controller
 	RewriteCond %{REQUEST_FILENAME} !-f
 	RewriteCond %{REQUEST_FILENAME} !-d
-	RewriteRule !\.(pdf|js|ico|gif|jpg|png|svg|css|rar|zip|tar\.gz|map)$ index.php [L]
+	RewriteRule !\.(pdf|js|ico|gif|jpg|jpeg|png|webp|svg|css|rar|zip|7z|tar\.gz|map|eot|ttf|otf|woff|woff2)$ index.php [L]
 </IfModule>
 
 # enable gzip compression

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -20,7 +20,7 @@
 	# front controller
 	RewriteCond %{REQUEST_FILENAME} !-f
 	RewriteCond %{REQUEST_FILENAME} !-d
-	RewriteRule !\.(pdf|js|ico|gif|jpg|png|css|rar|zip|tar\.gz|map)$ index.php [L]
+	RewriteRule !\.(pdf|js|ico|gif|jpg|png|svg|css|rar|zip|tar\.gz|map)$ index.php [L]
 </IfModule>
 
 # enable gzip compression

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -1,4 +1,5 @@
 # Apache configuration file (see httpd.apache.org/docs/current/mod/quickreference.html)
+Allow from all
 
 # disable directory listing
 <IfModule mod_autoindex.c>

--- a/www/checker/index.php
+++ b/www/checker/index.php
@@ -136,7 +136,7 @@ $tests[] = [
 $tests[] = [
 	'title' => 'ICONV extension',
 	'required' => true,
-	'passed' => extension_loaded('iconv') && (ICONV_IMPL !== 'unknown') && @iconv('UTF-16', 'UTF-8//IGNORE', iconv('UTF-8', 'UTF-16//IGNORE', 'test')) === 'test',
+	'passed' => extension_loaded('iconv') && @iconv('UTF-16', 'UTF-8//IGNORE', iconv('UTF-8', 'UTF-16//IGNORE', 'test')) === 'test',
 	'message' => 'Enabled and works properly',
 	'errorMessage' => 'Disabled or does not work properly',
 	'description' => 'ICONV extension is required and must work properly.',


### PR DESCRIPTION
Alpine Linux is a very common Linux distribution used in Docker images. But it has one problem. The official repository is missing the libiconv package needed to compile the ICONV PHP extensions.

There is one very well known thread that addresses this bug https://github.com/docker-library/php/issues/240. This is how Alpine Linux makes a functional extension of ICONV. One solution exists, LD_PRELOAD is used for this environment. 

RUN apk add gnu-libiconv --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ --allow-untrusted
ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php

You can install the gnu-libiconv package from the test repository to Alpine, but PHP will not recognize it. If I use the iconv function and I have this package installed in Alpine, everything works OK but phpinfo () says enabled => unknown. 
That's why I removed this rule from the checker. I think that a sufficient rule to verify the functionality of the ICONV extension is already applied: @iconv ('UTF-16', 'UTF-8 // IGNORE', iconv ('UTF-8', 'UTF-16 // IGNORE' test ')) ===' test '.