### PR TITLE
Remove composer platform

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,10 +39,5 @@
 	"autoload": {
 		"classmap": ["app/Bootstrap.php"]
 	},
-	"minimum-stability": "dev",
-	"config": {
-		"platform": {
-			"php": "7.1"
-		}
-	}
+	"minimum-stability": "dev"
 }


### PR DESCRIPTION
Thank you very much for forcing composer to install severely outdated versions of libraries that are compatible with this no longer supported PHP version and thus wasting my time debugging a nette noob's project. Seriously, how is a beginner supposed to debug a bullshit like this?

Howg.