### PR TITLE
.htaccess: PDF, CSS and JS can be routed by Nette.

### DIFF
--- a/www/.htaccess
+++ b/www/.htaccess
@@ -21,7 +21,7 @@ Require all granted
 	# front controller
 	RewriteCond %{REQUEST_FILENAME} !-f
 	RewriteCond %{REQUEST_FILENAME} !-d
-	RewriteRule !\.(pdf|js|mjs|ico|gif|jpg|jpeg|png|webp|svg|css|rar|zip|7z|tar\.gz|map|eot|ttf|otf|woff|woff2)$ index.php [L]
+	RewriteRule !\.(mjs|ico|gif|jpg|jpeg|png|webp|svg|rar|zip|7z|tar\.gz|map|eot|ttf|otf|woff|woff2)$ index.php [L]
 </IfModule>
 
 # enable gzip compression


### PR DESCRIPTION
Some projects load CSS and JS files directly from PHP because they use, for example, automatic compilation.

The default settings of .htaccess can be misleading and generate difficult-to-detect errors.